### PR TITLE
fix: getUTXOs order

### DIFF
--- a/src/services/apis/index.ts
+++ b/src/services/apis/index.ts
@@ -49,7 +49,7 @@ export default function (http: Http) {
 
     getUTXOs(membersHash, threshold, offset, limit): Promise<any> {
       return http.get(
-        `/multisigs/outputs?members=${membersHash}&threshold=${threshold}&offset=${offset}&limit=${limit}&order=created`,
+        `/multisigs/outputs?members=${membersHash}&threshold=${threshold}&offset=${offset}&limit=${limit}&order=updated`,
         {},
       );
     },


### PR DESCRIPTION
In `loadUTXOs` method, `updated_at` field is used as the offset. 
But in `getUTXOs` method it requests with `order=created`, which may cause UTXOs loss.